### PR TITLE
Support CommonMarkSettings via MarkdownViewEngineOptions

### DIFF
--- a/src/MarkdownViewEngine/MarkdownPage.cs
+++ b/src/MarkdownViewEngine/MarkdownPage.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
 using System;
 using System.IO;
 using System.Linq;
@@ -13,10 +14,13 @@ namespace MarkdownViewEngine
     public class MarkdownPage : IMarkdownPage
     {
         private readonly IFileProvider _contentRootFileProvider;
+        private readonly MarkdownViewEngineOptions _options;
 
-        public MarkdownPage(IFileProvider contentRootFileProvider)
+        public MarkdownPage(IFileProvider contentRootFileProvider,
+            MarkdownViewEngineOptions options)
         {
             _contentRootFileProvider = contentRootFileProvider;
+            _options = options;
         }
 
         public IHtmlContent BodyContent { get; set; }
@@ -61,7 +65,7 @@ namespace MarkdownViewEngine
                 markdown = content;
             }
 
-            var html = CommonMarkConverter.Convert(markdown);
+            var html = CommonMarkConverter.Convert(markdown, _options.MarkdownSettings);
             BodyContent = new HtmlString(html);
         }
     }

--- a/src/MarkdownViewEngine/MarkdownViewEngine.cs
+++ b/src/MarkdownViewEngine/MarkdownViewEngine.cs
@@ -108,7 +108,7 @@ namespace MarkdownViewEngine
                 var fileInfo = _contentRootFileProvider.GetFileInfo(view);
                 if (fileInfo.Exists)
                 {
-                    var page = new MarkdownPage(_contentRootFileProvider)
+                    var page = new MarkdownPage(_contentRootFileProvider, _options)
                     {
                         Path = view
                     };
@@ -130,7 +130,7 @@ namespace MarkdownViewEngine
                 return ViewEngineResult.NotFound(applicationRelativePath, Enumerable.Empty<string>());
             }
 
-            var page = new MarkdownPage(_contentRootFileProvider)
+            var page = new MarkdownPage(_contentRootFileProvider, _options)
             {
                 Path = applicationRelativePath
             };
@@ -188,7 +188,7 @@ namespace MarkdownViewEngine
                 var fileInfo = _contentRootFileProvider.GetFileInfo(view);
                 if (fileInfo.Exists)
                 {
-                    page = new MarkdownPage(_contentRootFileProvider)
+                    page = new MarkdownPage(_contentRootFileProvider, _options)
                     {
                         Path = view
                     };

--- a/src/MarkdownViewEngine/MarkdownViewEngineOptions.cs
+++ b/src/MarkdownViewEngine/MarkdownViewEngineOptions.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using CommonMark;
+using System.Collections.Generic;
 
 namespace MarkdownViewEngine
 {
     public class MarkdownViewEngineOptions
     {
         public IList<string> ViewLocationFormats { get; } = new List<string>();
+
+        public CommonMarkSettings MarkdownSettings { get; } = CommonMarkSettings.Default.Clone();
     }
 }


### PR DESCRIPTION
@jskeet this piece that required to expose ```CommonMarkSettings``` via ```MarkdownViewEngineOptions```, but i'm not sure if there 's an elegant way to support this via ```@Page``` directive

Perhaps some of the settings such as ```RenderSoftLineBreaksAsLineBreaks``` will be easy to implement, because there 's no CSharp parser yet that may simplify the process, so I think this suitable for app settings for at the moment